### PR TITLE
Use HTTPS by default and enable redirects.

### DIFF
--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -103,9 +103,11 @@ module AssetHost
       def connection
         @connection ||= begin
           Faraday.new(
-            :url    => "http://#{config.server}",
-            :params => { auth_token: config.token }
+            :url    => "https://#{config.server}",
+            :params => { auth_token: config.token },
+            :ssl => {version: :SSLv2}
           ) do |conn|
+            conn.use FaradayMiddleware::FollowRedirects
             conn.request :json
             conn.response :json
             conn.adapter Faraday.default_adapter


### PR DESCRIPTION
Is set to make HTTPS requests to AssetHost and follow redirects.