### PR TITLE
Fetch expiration

### DIFF
--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -57,7 +57,7 @@ module AssetHost
       def find(id)
         key = "asset/asset-#{id}"
 
-        if cached = Rails.cache.fetch(key, expires_in: 1.minute)
+        if cached = Rails.cache.fetch(key, {expires_in: 1.minute})
           return new(cached)
         end
 

--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -57,7 +57,7 @@ module AssetHost
       def find(id)
         key = "asset/asset-#{id}"
 
-        if cached = Rails.cache.read(key)
+        if cached = Rails.cache.fetch(key, expires_in: 1.minute)
           return new(cached)
         end
 

--- a/spec/lib/asset_host/asset_spec.rb
+++ b/spec/lib/asset_host/asset_spec.rb
@@ -76,7 +76,7 @@ describe AssetHost::Asset do
 
     context "good response" do
       it "writes to cache" do
-        Rails.cache.should_receive(:write).with("asset/asset-1", load_fixture("asset.json"))
+        Rails.cache.should_receive(:write).with("asset/asset-1", load_fixture("asset.json"), {expires_in: 1.minute})
         AssetHost::Asset.find(1)
       end
 


### PR DESCRIPTION
This is in conjunction with a PR for SCPRv4.

As AssetHostClient reads a cache_key, it also applies a 1 minute expiration. This is in response to a page like this: https://www.scpr.org/education, which has mixed content errors because these asset jsons were stored in the cache before the 1 minute expiration write logic was put into effect.

Also updates a test to expect the expiration rule.