### PR TITLE
Returns a fallback asset when the AssetHost request exceeds a specified timeout

### DIFF
--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -64,7 +64,7 @@ module AssetHost
         begin
             response = connection.get "#{config.prefix}/assets/#{id}"
         rescue
-            response = { body: nil, status: nil }
+            {}
         end
 
         json = response.body

--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -112,8 +112,8 @@ module AssetHost
             :params => { auth_token: config.token },
             :ssl => {verify: false},
             :request => {
-                :open_timeout => 0.001,
-                :timeout => 0.005
+                :open_timeout => 2,
+                :timeout => 5
             }
           ) do |conn|
             conn.use FaradayMiddleware::FollowRedirects

--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -64,9 +64,7 @@ module AssetHost
         begin
             response = connection.get "#{config.prefix}/assets/#{id}"
         rescue Faraday::Error::TimeoutError
-            response = Object.new
-            response.body = nil
-            response.status = nil
+            return Fallback.new
         end
 
         json = response.body

--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -106,8 +106,8 @@ module AssetHost
             :url    => "#{config.protocol || 'https'}://#{config.server}",
             :params => { auth_token: config.token },
             :ssl => {verify: false},
-            :open_timeout => 0.1,
-            :timeout => 0.5
+            :open_timeout => 0.001,
+            :timeout => 0.005
           ) do |conn|
             conn.use FaradayMiddleware::FollowRedirects
             conn.request :json

--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -112,8 +112,8 @@ module AssetHost
             :params => { auth_token: config.token },
             :ssl => {verify: false},
             :request => {
-                :open_timeout => 2,
-                :timeout => 5
+                :open_timeout => 1,
+                :timeout => 2
             }
           ) do |conn|
             conn.use FaradayMiddleware::FollowRedirects

--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -106,8 +106,10 @@ module AssetHost
             :url    => "#{config.protocol || 'https'}://#{config.server}",
             :params => { auth_token: config.token },
             :ssl => {verify: false},
-            :open_timeout => 0.001,
-            :timeout => 0.005
+            :request => {
+                :open_timeout => 0.001,
+                :timeout => 0.005
+            }
           ) do |conn|
             conn.use FaradayMiddleware::FollowRedirects
             conn.request :json

--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -63,8 +63,10 @@ module AssetHost
 
         begin
             response = connection.get "#{config.prefix}/assets/#{id}"
-        rescue
-            {}
+        rescue Faraday::Error::TimeoutError
+            response = Object.new
+            response.body = nil
+            response.status = nil
         end
 
         json = response.body

--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -105,7 +105,9 @@ module AssetHost
           Faraday.new(
             :url    => "#{config.protocol || 'https'}://#{config.server}",
             :params => { auth_token: config.token },
-            :ssl => {verify: false}
+            :ssl => {verify: false},
+            :open_timeout => 0.1,
+            :timeout => 0.5
           ) do |conn|
             conn.use FaradayMiddleware::FollowRedirects
             conn.request :json

--- a/lib/asset_host/asset.rb
+++ b/lib/asset_host/asset.rb
@@ -61,7 +61,12 @@ module AssetHost
           return new(cached)
         end
 
-        response = connection.get "#{config.prefix}/assets/#{id}"
+        begin
+            response = connection.get "#{config.prefix}/assets/#{id}"
+        rescue
+            response = { body: nil, status: nil }
+        end
+
         json = response.body
 
         if !GOOD_STATUS.include?(response.status.to_i) || !json

--- a/lib/asset_host_client/version.rb
+++ b/lib/asset_host_client/version.rb
@@ -1,3 +1,3 @@
 module AssetHostClient
-  VERSION = "2.1.5"
+  VERSION = "2.1.6"
 end


### PR DESCRIPTION
The changes proposed here:
- Sets an open connection timeout of 2 seconds
- Sets a read connection timeout of 5 seconds

It uses the `open_timeout` and `timeout` request options exposed by Faraday:
- https://www.rubydoc.info/gems/faraday/0.8.9/Faraday%2FRequest:to_env
- https://github.com/lostisland/faraday/issues/417

This is designed to prevent requests from hanging for an inordinate amount of time. Some requests can go as long as 20+ seconds:
![screen shot 2018-12-28 at 1 50 18 pm](https://user-images.githubusercontent.com/16679701/50529143-affe3700-0aa7-11e9-9b95-75387a4ae398.png)

Also adds a test spec to ensure that a fallback is returned if a `Faraday::Error::TimeoutError` is raised, and fixes another test that still assumed the ttl was 1 minute (recently changed to 30 minutes).